### PR TITLE
Fix module name typo in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bu/git-access-limit
+module github.com/bu/gin-access-limit
 
 go 1.14
 


### PR DESCRIPTION
This typo caused an error during dependency installation:

github.com/bu/gin-access-limit: github.com/bu/gin-access-limit@v1.0.0: parsing go.mod:
        module declares its path as: github.com/bu/git-access-limit
        but was required as: github.com/bu/gin-access-limit